### PR TITLE
V2.0.4 feature fix/remove copying private data and change to docker volume

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@ postgres_data
 README.md
 request_himatro_api.log.json
 error.log
-private_data
+**/private_data

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ postgres_data
 README.md
 request_himatro_api.log.json
 error.log
+private_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,6 @@ WORKDIR /app/src
 COPY . .
 RUN go build -o /app/bin/main main.go
 
-WORKDIR /app/private_data
-
-COPY private_data/ .
-
 EXPOSE 8080
 
 WORKDIR /app

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,6 +13,7 @@ services:
   #     - "./.env:/app/.env"
   #     - "/var/log/request_himatro_api.log.json:/app/request_himatro_api.log.json"
   #     - "/var/log/error_himatro_api.log:/app/error.log"
+  #     - "./private_data/:/app/private_data"
 
   postgres:
     image: postgres:14

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,7 +13,7 @@ services:
   #     - "./.env:/app/.env"
   #     - "/var/log/request_himatro_api.log.json:/app/request_himatro_api.log.json"
   #     - "/var/log/error_himatro_api.log:/app/error.log"
-  #     - "./private_data/:/app/private_data"
+  #     - "./private_data/:/app/private_data/"
 
   postgres:
     image: postgres:14


### PR DESCRIPTION
v2.0.4 add feature fix to generated docker image not to copy the private_data files to the image, but only create volumes to the parent private_data folder